### PR TITLE
Fix(SC06): make contract vulnerable, fix translation errors

### DIFF
--- a/2025/FA/src/SC06-unchecked-external-calls.md
+++ b/2025/FA/src/SC06-unchecked-external-calls.md
@@ -4,19 +4,19 @@
 این آسیب‌پذیری زمانی رخ می‌دهد که یک قرارداد هوشمند در اتریوم یک فراخوانی خارجی به قرارداد یا آدرس دیگری ارسال می‌کند بدون اینکه نتیجه‌ی آن فراخوانی را بررسی کند. در اتریوم، زمانی که یک قرارداد، قراردادی دیگر را فراخوانی می‌کند، ممکن است قرارداد فراخوانی‌شده بدون ایجاد استثنا (Exception) با شکست مواجه شود. اگر قرارداد فراخوانی‌کننده نتیجه‌ی این فراخوانی را بررسی نکند، ممکن است به اشتباه فرض کند که عملیات موفق بوده است، حتی اگر شکست خورده باشد. این موضوع می‌تواند منجر به ناسازگاری در حالت (state) قرارداد و ایجاد آسیب‌پذیری‌هایی شود که مهاجمان می‌توانند از آن سوءاستفاده کنند.
 
 ### مثال (قرارداد آسیب پذیر):
-```
+```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.4.24;
+pragma solidity ^0.8.0;
 
 contract Solidity_UncheckedExternalCall {
     address public owner;
 
-    constructor() public {
+    constructor() {
         owner = msg.sender;
     }
 
-    function forward(address callee, bytes _data) public {
-        require(callee.delegatecall(_data));
+    function forward(address callee, bytes memory _data) public {
+        callee.delegatecall(_data);
     }
 }
 ```
@@ -29,11 +29,11 @@ contract Solidity_UncheckedExternalCall {
 - همیشه نتیجه‌ی فراخوانی‌های send() یا call() را بررسی کنید تا در صورت بازگشت false به درستی مدیریت شود.
 
 ### مثال (قرار داد اصلاح شده):
-```
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0; 
 
-contract Solidity_UncheckedExternalCall {
+contract Solidity_CheckedExternalCall {
     address public owner;
 
     constructor() {

--- a/2025/en/src/SC06-unchecked-external-calls.md
+++ b/2025/en/src/SC06-unchecked-external-calls.md
@@ -4,19 +4,19 @@
 Unchecked external calls refer to a security flaw where a contract makes an external call to another contract or address without properly checking the outcome of that call. In Ethereum, when a contract calls another contract, the called contract can fail silently without throwing an exception. If the calling contract doesn’t check the return value, it might incorrectly assume the call was successful, even if it wasn't. This can lead to inconsistencies in the contract state and vulnerabilities that attackers can exploit.
 
 ### Example (Vulnerable contract):
-```
+```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.4.24;
+pragma solidity ^0.8.0;
 
 contract Solidity_UncheckedExternalCall {
     address public owner;
 
-    constructor() public {
+    constructor() {
         owner = msg.sender;
     }
 
-    function forward(address callee, bytes _data) public {
-        require(callee.delegatecall(_data));
+    function forward(address callee, bytes memory _data) public {
+        callee.delegatecall(_data);
     }
 }
 ```
@@ -28,11 +28,11 @@ contract Solidity_UncheckedExternalCall {
 - Always check the return value of send() or call() functions to ensure proper handling if they return false.
 
 ### Example (Fixed version):
-```
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0; 
 
-contract Solidity_UncheckedExternalCall {
+contract Solidity_CheckedExternalCall {
     address public owner;
 
     constructor() {
@@ -46,6 +46,14 @@ contract Solidity_UncheckedExternalCall {
     }
 }
 ```
+
+### Caveats
+
+The two contracts above contain weaknesses beyond an unchecked return value.
+
+- Authentication is delegated to the callee. The code of the called contract may, or may not, restrict the `msg.sender`, e.g. by comparing it to `owner`. Normally, the function `forward` should perform some form of authentication.
+- `callee` is an address provided by the user. This means that arbitrary code can be executed in the context of this contract, modifying e.g.\ `owner`. This is particularly problematic, as `forward` does not perform authentication.
+- The address `callee` is not checked for being a contract. If `callee` is an address without code, this will go unnoticed, as `delegatecall` succeeds. Normally, the function `forward` should do basic checks, like verifying that the code size of the called contract is larger than zero.
 
 ### Examples of Smart Contracts That Fell Victim to Unchecked External Call Attacks:
 1. [Punk Protocol Hack](https://github.com/PunkFinance/punk.protocol/blob/master/contracts/models/CompoundModel.sol) : A Comprehensive [Hack Analysis](https://blog.solidityscan.com/security-issues-with-delegate-calls-4ae64d775b76)

--- a/2025/es/src/SC06-unchecked-external-calls.md
+++ b/2025/es/src/SC06-unchecked-external-calls.md
@@ -6,17 +6,17 @@ Las llamadas externas no comprobadas se refieren a un fallo de seguridad en el q
 ### Ejemplo (Contrato vulnerable):
 ```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.4.24;
+pragma solidity ^0.8.0;
 
 contract Solidity_UncheckedExternalCall {
     address public owner;
 
-    constructor() public {
+    constructor() {
         owner = msg.sender;
     }
 
-    function forward(address callee, bytes _data) public {
-        require(callee.delegatecall(_data));
+    function forward(address callee, bytes memory _data) public {
+        callee.delegatecall(_data);
     }
 }
 ```
@@ -32,7 +32,7 @@ contract Solidity_UncheckedExternalCall {
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0; 
 
-contract Solidity_UncheckedExternalCall {
+contract Solidity_CheckedExternalCall {
     address public owner;
 
     constructor() {
@@ -41,11 +41,19 @@ contract Solidity_UncheckedExternalCall {
 
     function forward(address callee, bytes memory _data) public {
         // Asegurarse que delegatecall tiene éxito
-        (bool éxito, ) = callee.delegatecall(_datos);
-        require(success, «Delegatecall failed»); // Comprueba el valor de retorno para manejar el fallo
+        (bool success, ) = callee.delegatecall(_data);
+        require(success, "Delegatecall failed"); // Comprueba el valor de retorno para manejar el fallo
     }
 }
 ```
+
+### Advertencias
+
+Los dos contratos anteriores contienen debilidades más allá de un valor de retorno no verificado.
+
+- La autenticación se delega al contrato llamado. El código del contrato llamado puede, o no, restringir el valor de `msg.sender`, por ejemplo, comparándolo con `owner`. Normalmente, la función `forward` debería realizar algún tipo de autenticación.
+- `callee` es una dirección proporcionada por el usuario. Esto significa que se puede ejecutar código arbitrario en el contexto de este contrato, modificando por ejemplo `owner`. Esto es particularmente problemático, ya que `forward` no realiza autenticación.
+- No se verifica si la dirección `callee` corresponde a un contrato. Si `callee` es una dirección sin código, esto pasará desapercibido, ya que `delegatecall` tendrá éxito. Normalmente, la función `forward` debería hacer verificaciones básicas, como confirmar que el tamaño del código del contrato llamado sea mayor que cero.
 
 ### Ejemplos de Contratos Inteligentes que fueron Víctimas de Ataques de Llamadas Externas sin Control:
 1. [Protocolo Punk](https://github.com/PunkFinance/punk.protocol/blob/master/contracts/models/CompoundModel.sol) :Un completo [Análisis del Hackeo](https://blog.solidityscan.com/security-issues-with-delegate-calls-4ae64d775b76)

--- a/2025/zh-cn/src/SC06-unchecked-external-calls.md
+++ b/2025/zh-cn/src/SC06-unchecked-external-calls.md
@@ -4,19 +4,19 @@
 未经检查的外部调用是一种安全漏洞，指的是合约在调用另一个合约或地址时，没有正确验证调用结果。在以太坊中，当一个合约调用另一个合约时，被调用的合约可能会默默失败，而不会抛出异常。如果调用合约没有检查返回值，就可能错误地假设调用成功，尽管实际情况是失败的。这种情况可能导致合约状态不一致，并为攻击者提供利用漏洞的机会。
 
 ### 举例 (包含漏洞的合约):
-```
+```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.4.24;
+pragma solidity ^0.8.0;
 
 contract Solidity_UncheckedExternalCall {
     address public owner;
 
-    constructor() public {
+    constructor() {
         owner = msg.sender;
     }
 
-    function forward(address callee, bytes _data) public {
-        require(callee.delegatecall(_data));
+    function forward(address callee, bytes memory _data) public {
+        callee.delegatecall(_data);
     }
 }
 ```
@@ -28,11 +28,11 @@ contract Solidity_UncheckedExternalCall {
 - 始终检查 `send()` 或 `call()` 的返回值，并在返回 `false` 时进行适当处理。
 
 ### 举例 (已修复版本):
-```
+```solidity
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0; 
+pragma solidity ^0.8.0;
 
-contract Solidity_UncheckedExternalCall {
+contract Solidity_CheckedExternalCall {
     address public owner;
 
     constructor() {


### PR DESCRIPTION
- The sample contracts marked as vulnerable actually weren't vulnerable (fixes issue #34); `require` removed.
- Better use recent compiler versions, to avoid the impression that the vulnerability is related to the old compiler version.
- Fix variable names in the Spanish version that were accidentally translated (but only partially).